### PR TITLE
Uppercase UITableViewIndex

### DIFF
--- a/ATLApplicationListControllerBase.m
+++ b/ATLApplicationListControllerBase.m
@@ -351,7 +351,7 @@
 
 	[_specifiers enumerateObjectsUsingBlock:^(PSSpecifier* specifier, NSUInteger idx, BOOL *stop)
 	{
-		NSString* firstLetter = [specifier.name substringToIndex:1].lowercaseString;
+		NSString* firstLetter = [specifier.name substringToIndex:1].uppercaseString;
 		NSMutableArray* letterSpecifiers = [_specifiersByLetter objectForKey:firstLetter];
 		if(!letterSpecifiers)
 		{
@@ -368,7 +368,7 @@
 	NSMutableArray* letterGroupedSpecifiers = [NSMutableArray new];
 	for(char c = 'a'; c <= 'z'; c++)
 	{
-		NSString* cString = [NSString stringWithFormat:@"%c", c];
+		NSString* cString = [NSString stringWithFormat:@"%c", c].uppercaseString;
 		NSMutableArray* letterSpecifiers = [_specifiersByLetter objectForKey:cString];
 		if(letterSpecifiers)
 		{

--- a/AltList.x
+++ b/AltList.x
@@ -4,7 +4,7 @@
 //Pre heat display names
 %ctor
 {
-	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^(void){
+	dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), ^{
 		[[[LSApplicationWorkspace defaultWorkspace] allInstalledApplications] enumerateObjectsUsingBlock:^(LSApplicationProxy* proxy, NSUInteger idx, BOOL *stop)
 		{
 			[proxy atl_fastDisplayName];


### PR DESCRIPTION
Uppercase letters at the right of the list when there is only one section, to make it more consistent with iOS. Should work but I wasn't able to test due to linker issues.