### PR TITLE
Better Portuguese localization

### DIFF
--- a/Resources/pt.lproj/Localizable.strings
+++ b/Resources/pt.lproj/Localizable.strings
@@ -1,4 +1,4 @@
-"Applications" = "Aplicações";
-"System Applications" = "Aplicações do Sistema";
-"User Applications" = "Aplicações do Usuário";
-"Hidden Applications" = "Aplicações Ocultas";
+"Applications" = "Aplicativos";
+"System Applications" = "Aplicativos do Sistema";
+"User Applications" = "Aplicativos do Usuário";
+"Hidden Applications" = "Aplicativos Ocultos";


### PR DESCRIPTION
It's better to use "Aplicativos" (more suitable to mobile apps) in Portuguese than "Aplicações" (IMHO more suitable to desktop applications).